### PR TITLE
Fix wrong config for Webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,13 @@ module.exports = {
         use: [
           'style-loader', // or MiniCssExtractPlugin.loader
           'css-loader',
--         'postcss-loader',
-+         ['parcel-css-loader', { implementation: parcelCSS }]
+          'postcss-loader',
+          {
+            loader: 'parcel-css-loader',
+            options: {
+              implementation: parcelCSS
+            }
+          }
           'sass-loader'
         ],
       },


### PR DESCRIPTION
Config seems to be following Babel config way but it's not working as expected and Webpack es complaining.

We need to use an object in order to define the implementation.